### PR TITLE
fix scalefactor on constructor:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,17 @@ jobs:
       - name: Use Node.js 18.x
         uses: actions/setup-node@v1
         with:
-          node-version: 18.x
-      - name: install npm v8
+          node-version: 20.x
+      - name: install npm v22
         run: npm i -g npm@8
       - name: install
-        run:  npm install
+        run: npm install
       - name: build
-        run:  npm run build
+        run: npm run build
       - name: Publish
         uses: menduz/oddish-action@master
         with:
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
           access: public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "dist"
   ],
   "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=6.0.0",
+    "node": ">=20.0.0",
+    "npm": ">=22.0.0",
     "yarn": "please use npm"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,11 +33,6 @@
   "files": [
     "dist"
   ],
-  "engines": {
-    "node": ">=20.0.0",
-    "npm": ">=22.0.0",
-    "yarn": "please use npm"
-  },
   "devDependencies": {
     "@dcl/sdk": "latest",
     "prettier": "^2.8.7",

--- a/src/ui-entities/prompts/Prompt/components/Button/index.tsx
+++ b/src/ui-entities/prompts/Prompt/components/Button/index.tsx
@@ -83,9 +83,9 @@ const promptButtonInitialConfig: Omit<Required<PromptButtonConfig>, 'parent'> = 
 export class PromptButton extends InPromptUIObject {
   public labelElement: PromptButtonLabelElementProps
   public imageElement: PromptButtonImageElementProps
-  public imageElementCorner: PromptButtonImageElementProps
-  public imageElementEdge: PromptButtonImageElementProps
-  public iconElement: PromptButtonIconElementProps
+  public imageElementCorner: () => PromptButtonImageElementProps
+  public imageElementEdge: () => PromptButtonImageElementProps
+  public iconElement: () => PromptButtonIconElementProps
 
   public text: string | number
   public xPosition: number
@@ -122,8 +122,8 @@ export class PromptButton extends InPromptUIObject {
     })
 
     this.text = text
-    this.xPosition = xPosition * scaleFactor
-    this.yPosition = yPosition * scaleFactor
+    this.xPosition = xPosition
+    this.yPosition = yPosition
     this.positionAbsolute = positionAbsolute,
     this.onMouseDown = onMouseDown
 
@@ -135,8 +135,8 @@ export class PromptButton extends InPromptUIObject {
     this._isFStyle = this._style === PromptButtonStyles.F
 
 
-    this._width = 174 * scaleFactor
-    this._height = 46 * scaleFactor
+    this._width = 174
+    this._height = 46
 
     let buttonImg: PromptButtonCustomBgStyles | PromptButtonStyles = this._style
     let buttonImgCorn: PromptButtonCustomBgStyles | PromptButtonStyles = this._style
@@ -188,7 +188,7 @@ export class PromptButton extends InPromptUIObject {
       },
     }
 
-    this.imageElementCorner = {
+    this.imageElementCorner = () => ({
       uiTransform: {
         height: this._height ,
         width: 12 * scaleFactor
@@ -204,9 +204,9 @@ export class PromptButton extends InPromptUIObject {
           atlasWidth: sourcesComponentsCoordinates.atlasWidth,
         }),
       },
-    }
+    })
 
-    this.imageElementEdge = {
+    this.imageElementEdge = () => ({
       uiTransform: {
         height: this._height,
         width: 12 * scaleFactor,
@@ -223,9 +223,9 @@ export class PromptButton extends InPromptUIObject {
           atlasWidth: sourcesComponentsCoordinates.atlasWidth,
         }),
       },
-    }
+    })
 
-    this.iconElement = {
+    this.iconElement = () => ({
       uiTransform: {
         width: 26 * scaleFactor,
         height: 26 * scaleFactor,
@@ -246,7 +246,7 @@ export class PromptButton extends InPromptUIObject {
           atlasWidth: sourcesComponentsCoordinates.atlasWidth,
         }),
       },
-    }
+    })
 
     this._createSystemInputAction()
   }
@@ -272,8 +272,8 @@ export class PromptButton extends InPromptUIObject {
   }
 
   public render(key?: string): ReactEcs.JSX.Element {
-    this._xPosition = this.promptWidth / -2 + this._width / 2 + this.xPosition
-    this._yPosition = this.promptHeight / 2 + this._height / -2 + this.yPosition
+    this._xPosition = this.promptWidth / -2 + this._width * scaleFactor / 2 + (this.xPosition * scaleFactor)
+    this._yPosition = this.promptHeight / 2 + this._height * scaleFactor / -2 + (this.yPosition * scaleFactor)
 
     return (
       <UiEntity
@@ -295,7 +295,7 @@ export class PromptButton extends InPromptUIObject {
           this._click()
         }}
       >
-        <UiEntity {...this.imageElementCorner}/>
+        <UiEntity {...this.imageElementCorner()}/>
         <UiEntity
           {...this.imageElement}
           uiTransform={{
@@ -303,9 +303,9 @@ export class PromptButton extends InPromptUIObject {
           }}
         >
           <UiEntity
-            {...this.iconElement}
+            {...this.iconElement()}
             uiTransform={{
-              ...this.iconElement.uiTransform,
+              ...this.iconElement().uiTransform,
               display: this._disabled || (!this._isEStyle && !this._isFStyle) ? 'none' : 'flex',
               margin: {
                 top: -26 / 2 * scaleFactor,
@@ -329,7 +329,7 @@ export class PromptButton extends InPromptUIObject {
             }}
           />
         </UiEntity>
-        <UiEntity {...this.imageElementEdge}/>
+        <UiEntity {...this.imageElementEdge()}/>
       </UiEntity>
     )
   }
@@ -337,7 +337,7 @@ export class PromptButton extends InPromptUIObject {
   private _click = (): void => {
     if (this._disabled || !this.visible || !this.isPromptVisible) return
 
-  
+
     console.log('prompt button _click_________________')
 
     this.onMouseDown()


### PR DESCRIPTION
This is why i dont like this approach of classes. It ends up with non wanted behaivour.
React-ecs should be funcionts that returns the component on every tick and react to changes on that props.
We create react-ecs to avoid having classes and instances and constructors at all, it should all live inside the component and run on every render. 


I think this fixes the problem with scaleFactor, because it was being cached on the constructor and never calculated again.